### PR TITLE
use $DRAFT_HOME rather than $(draft home)

### DIFF
--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -25,7 +25,7 @@
 PROJECT_NAME="draft-pack-repo"
 PROJECT_GH="Azure/$PROJECT_NAME"
 
-: ${DRAFT_PLUGIN_PATH:="$(draft home)/plugins/draft-pack-repo"}
+: ${DRAFT_PLUGIN_PATH:="$DRAFT_HOME/plugins/draft-pack-repo"}
 : ${VERSION:="canary"}
 
 if [[ $SKIP_BIN_INSTALL == "1" ]]; then


### PR DESCRIPTION
$DRAFT_HOME is always known to be present when installing plugins,
whereas $(draft home) may not work if `draft` is not on the $PATH.

closes #9 